### PR TITLE
Add python 3 support

### DIFF
--- a/mailing/mail.py
+++ b/mailing/mail.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.template.loader import render_to_string
+from django.utils import six
 from django.utils import translation
 
 # Define exception classes
@@ -58,7 +59,7 @@ def send_email(recipients, subject, text_content=None, html_content=None, from_e
 
         # Ensure recipients are in a list
         # --------------------------------
-        if isinstance(recipients, basestring):
+        if isinstance(recipients, six.string_types):
             recipients_list = [recipients]
         else:
             recipients_list = recipients

--- a/mailing/mail.py
+++ b/mailing/mail.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.template.loader import render_to_string
-from django.utils import six
+import six
 from django.utils import translation
 
 # Define exception classes

--- a/mailing/tasks.py
+++ b/mailing/tasks.py
@@ -2,8 +2,8 @@ from django.conf import settings
 
 from celery.task import task
 
-from mail import send_email
-from shortcuts import render_send_email
+from mailing.mail import send_email
+from mailing.shortcuts import render_send_email
 
 @task(name="mailing.queue_send_email")
 def queue_send_email(recipients, subject, text_content=None, html_content=None, from_email=settings.DEFAULT_FROM_EMAIL, use_base_template=True, category=None, fail_silently=False, language=None, cc=None, bcc=None, attachments=None, headers=None, bypass_hijacking=False, attach_files=None): 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "redis >= 2.4.10",
         "celery",
         "django-celery",
+	"six",
     ],
     package_data={'mailing': ['templates/mailing/base.html', 'templates/mailing/base.txt']},
 )


### PR DESCRIPTION
in python3 some changes was made:
1) absolute imports are enabled by default.
2) string types also was changed, so it's more correct to use six package to support both python versions
